### PR TITLE
Added Brute-Fruit Module

### DIFF
--- a/Find-Fruit.ps1
+++ b/Find-Fruit.ps1
@@ -487,6 +487,10 @@ param (
                         $WebResponse = $WebRequest.Timeout = $Timeout
                         $WebResponse = $WebRequest.GetResponse()
                         $WebStatus = $WebResponse.StatusCode
+                        $Stream = $WebResponse.GetResponseStream()
+                        $Reader = New-Object IO.StreamReader($Stream)
+                        $html = $reader.ReadToEnd()
+                        $WebSize = $html.Length
                         $ResultObject += $ScanObject
                         $WebResponse.Close()
                     }
@@ -505,6 +509,7 @@ param (
                     $Result = @{
                         Status = $WebStatus;
                         URL = $WebTarget
+                        Size = $WebSize
                     }
                     
                     if ($FoundOnly) {


### PR DESCRIPTION
The Brute-Fruit module is for directory and file brute-forcing against multiple web servers. It accepts a list of web servers (-UrlList) and a dictionary file (-Dictionary) to perform brute forcing against. Think "Dirbusting across a broad range of hosts". It also changed the multi-threading functionality that was being used in the Find-Fruit module so that it breaks out each thread by file/directory instead of by host.