### PR TITLE
Refactoring, cross platform support

### DIFF
--- a/FileSplitter.ps1
+++ b/FileSplitter.ps1
@@ -1,87 +1,121 @@
-function Split-File {
+function Split-File
+{
+    <#-- Another stackoverflow production
+    https://stackoverflow.com/questions/4533570/in-powershell-how-do-i-split-a-large-binary-file
+    --#>
 
-<#-- Another stackoverflow production 
-https://stackoverflow.com/questions/4533570/in-powershell-how-do-i-split-a-large-binary-file
---#>
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory = $true, ValueFromPipeLine = $true, ValueFromPipelineByPropertyName = $true)]
+        [String]
+        $InputFile,
 
-  [CmdletBinding()]
-  Param (
-    [Parameter(Mandatory = $true, ValueFromPipeLine = $true, ValueFromPipelineByPropertyName = $true)]
-    [String]
-    $InputFile,
-    [Parameter(Mandatory = $true)]
-    [String]
-    $OutDirectory,
-    [Parameter(Mandatory = $false)]
-    [String]
-    $OutputFilePrefix = "chunk",
-    [Parameter(Mandatory = $false)]
-    [Int32]
-    $ChunkSize = 1024
-  )
+        [Parameter(Mandatory = $true)]
+        [String]
+        $OutputDirectory,
 
-  Begin {
-    Write-Output "Beginning to split your file.."
-  }
+        [Parameter(Mandatory = $false)]
+        [String]
+        $OutputFilePrefix = "chunk",
 
-  Process {
-    $FileStream = [System.IO.File]::OpenRead($InputFile)
-    $ByteChunks = New-Object byte[] $ChunkSize
-    $ChunkNumber = 1
-    While($BytesRead = $FileStream.Read($ByteChunks,0,$ChunkSize)) {
-      $OutputFile = "$OutputFilePrefix$ChunkNumber"     
-      $OutputStream = [System.IO.File]::OpenWrite("$OutDirectory`\$OutputFile")
-      $OutputStream.Write($ByteChunks,0,$BytesRead)
-      $OutputStream.Close()
-      Write-Verbose "Wrote File $OutputFile"
-      $ChunkNumber += 1
+        [Parameter(Mandatory = $false)]
+        [Int32]
+        $ChunkSize = 4096
+    )
+
+    Begin
+    {
+        Write-Output "Beginning file split..."
     }
-  }
 
-  End {
-    Write-Output "Finished splitting your file!"
-  }
+    Process
+    {
+        if (-not (Test-Path -Path $OutputDirectory))
+        {
+            New-Item -ItemType Directory $OutputDirectory | Out-Null
+            Write-Verbose "Created OutputDirectory: $OutputDirectory"
+        }
+
+        $FileStream = [System.IO.File]::OpenRead($InputFile)
+        $ByteChunks = New-Object byte[] $ChunkSize
+        $ChunkNumber = 1
+
+        While ($BytesRead = $FileStream.Read($ByteChunks, 0, $ChunkSize))
+        {
+            $OutputFile = Join-Path -Path $OutputDirectory -ChildPath "$OutputFilePrefix$ChunkNumber"
+            $OutputStream = [System.IO.File]::OpenWrite($OutputFile)
+            $OutputStream.Write($ByteChunks, 0, $BytesRead)
+
+            $OutputStream.Close()
+
+            Write-Verbose "Wrote File: $OutputFile"
+
+            $ChunkNumber += 1
+        }
+    }
+
+    End
+    {
+        Write-Output "Finished splitting file."
+    }
 }
 
-
-
-
-function Reassemble-File {
+function Unsplit-File
+{
     [CmdletBinding()]
     Param (
         [Parameter(Mandatory = $true)]
         [String]
-        $InputFileDirectory,
-        [Parameter(Mandatory = $true)]
+        $InputDirectory,
+
+        [Parameter(Mandatory = $false)]
         [String]
-        $InputfilePrefix = "chunk",
+        $InputFilePrefix = "chunk",
+
         [Parameter(Mandatory = $true)]
         [String]
         $OutputDirectory,
+
         [Parameter(Mandatory = $true)]
         [String]
         $OutputFile
     )
 
-    Begin {
-        Write-Output "Beginning to reassemble your files.."
+    Begin
+    {
+        Write-Output "Beginning file unsplit..."
     }
 
-    Process {
-        $OutputStream = [System.Io.File]::OpenWrite("$OutputDirectory`\$OutputFile")
+    Process
+    {
+        if (-not (Test-Path -Path $OutputDirectory))
+        {
+            New-Item -ItemType Directory $OutputDirectory | Out-Null
+            Write-Verbose "Created OutputDirectory: $OutputDirectory"
+        }
+
+        $OutputPath = Join-Path -Path $OutputDirectory -ChildPath $OutputFile
+        $OutputStream = [System.Io.File]::OpenWrite($OutputPath)
+
         $ChunkNumber = 1
-        $InputFilename = "$InputFileDirectory`\$InputfilePrefix$ChunkNumber"
-        $Offset = 0
-        while(Test-Path $InputFilename) {
+        $InputFilename = Join-Path -Path $InputDirectory -ChildPath "$InputFilePrefix$ChunkNumber"
+
+        while (Test-Path $InputFilename)
+        {
             $FileBytes = [System.IO.File]::ReadAllBytes($InputFilename)
             $OutputStream.Write($FileBytes, 0, $FileBytes.Count)
+
+            Write-Verbose "Unsplit File: $InputFilename"
+
             $ChunkNumber += 1
-            $InputFilename = "$InputFileDirectory`\$InputfilePrefix$ChunkNumber"
+            $InputFilename = Join-Path -Path $InputDirectory -ChildPath "$InputFilePrefix$ChunkNumber"
         }
-        $OutputStream.close()   
+
+        $OutputStream.close()
     }
-    End {
-        
-        Write-Output "Finished assembly!"
-    }   
+
+    End
+    {
+        Write-Output "Finished unsplitting file."
+    }
 }


### PR DESCRIPTION
- Default ChunkSize to a slightly larger file size, `4096` instead of `1024`
- Use `Join-Path` instead of literal back-slashes in path to support non-Windows platforms
- Rename `Reassemble-File` function to `Unsplit-File`
- Create output directories if they don't exist
- Remove mandatory requirement for OutputFilePrefix parameter, since there's already a default (`chunk`)