### PR TITLE
Update OfficeMemScraper.ps1

### DIFF
--- a/OfficeMemScraper.ps1
+++ b/OfficeMemScraper.ps1
@@ -176,7 +176,7 @@ function Invoke-OfficeScrape {
             foreach ($d in $dumps) {
                 Write-Output "Scraping memory dump: $($d.FullName)"
                 $output = select-string -Path $d.FullName -Pattern eyJ0eX   
-                $output | out-file -encoding ascii $outfile
+                $output | out-file -append -encoding ascii $outfile
             }
         }
         else {


### PR DESCRIPTION
Added the "-append" flag for the out-file function. When there is more than one process, the tool will iterate over each of them, create a dump and then out-file the results, overwriting them on each iteration.

In my case I dumped msedge.exe, which had 10 processes running. The Token for office.com was only contained in one of the dumps.

With this addition, we can preserve all findings in one file :)